### PR TITLE
feat: True Chitra ayanamsa backend integration

### DIFF
--- a/services/client-service/src/clients/astro-engine.client.ts
+++ b/services/client-service/src/clients/astro-engine.client.ts
@@ -7,7 +7,7 @@ import { decompressChartData } from "../utils/compression";
 // Types & Interfaces
 // =============================================================================
 
-export type Ayanamsa = "lahiri" | "raman" | "kp" | "yukteswar" | "bhasin" | "western" | "universal";
+export type Ayanamsa = "lahiri" | "raman" | "kp" | "yukteswar" | "bhasin" | "true_chitra" | "western" | "universal";
 
 export interface BirthData {
   birthDate: string; // YYYY-MM-DD
@@ -379,6 +379,47 @@ class AstroEngineClient {
   }
 
   /**
+   * Get True Chitra Dasha Systems
+   * Maps dasha types to exact Python Astro Engine endpoint paths.
+   * The True Chitra routes use inconsistent naming (_dasha suffixes, _sama, etc.)
+   */
+  async getTrueChitraDasha(
+    birthData: BirthData,
+    dashaType: string,
+  ): Promise<AstroResponse> {
+    logger.info({ dashaType }, "Generating True Chitra Dasha");
+
+    const type = dashaType.toLowerCase().replace(/-dasha$/, "").replace(/_/g, "-");
+
+    // Exact endpoint mapping to match Python route definitions in TrueChitraAynamsa.py
+    const endpointMap: Record<string, string> = {
+      "prana": "/true_chitra/prana_dasha",
+      "ashtottari": "/true_chitra/ashtottari_dasha",
+      "tribhagi": "/true_chitra/tribhagi_dasha",
+      "tribhagi-40": "/true_chitra/tribhagi40_dasha",
+      "tribhagi40": "/true_chitra/tribhagi40_dasha",
+      "shodashottari": "/true_chitra/shodashottari_dasha",
+      "dwadashottari": "/true_chitra/dwadashottari_dasha",
+      "dwisaptati": "/true_chitra/dwisaptati_sama",
+      "dwisaptati-sama": "/true_chitra/dwisaptati_sama",
+      "shastihayani": "/true_chitra/shastihayani_dasha",
+      "shattrimshatsama": "/true_chitra/shattrimshatsama",
+      "panchottari": "/true_chitra/panchottari_dasha",
+      "satabdika": "/true_chitra/shatabdika_dasha",
+      "shatabdika": "/true_chitra/shatabdika_dasha",
+      "chaturshitisama": "/true_chitra/calculate_chaturshitisama_dasha",
+    };
+
+    const endpoint = endpointMap[type];
+    if (!endpoint) {
+      logger.error({ dashaType, normalizedType: type }, "Unknown True Chitra dasha type");
+      throw new AstroEngineError(`Unknown True Chitra dasha type: ${dashaType}`, 400);
+    }
+
+    return (await this.apiClient.post(endpoint, birthData)).data;
+  }
+
+  /**
    * Get Other Dasha Systems (Tribhagi, Shodashottari, Dwadashottari, etc.)
    * Routes to /internal/dasha/other?type=<dashaType>
    */
@@ -393,6 +434,11 @@ class AstroEngineClient {
     } = {},
   ): Promise<AstroResponse> {
     logger.info({ ayanamsa, dashaType, options }, "Generating Other Dasha");
+
+    // True Chitra uses its own dedicated endpoint structure
+    if (ayanamsa === "true_chitra") {
+      return this.getTrueChitraDasha(birthData, dashaType);
+    }
 
     // Normalize dasha type for the engine (especially for Yukteswar)
     const type = this.getNormalizedDashaType(dashaType, ayanamsa);

--- a/services/client-service/src/config/endpoint-availability.ts
+++ b/services/client-service/src/config/endpoint-availability.ts
@@ -13,6 +13,7 @@ export type AyanamsaSystem =
   | "kp"
   | "yukteswar"
   | "bhasin"
+  | "true_chitra"
   | "western"
   | "universal";
 
@@ -465,6 +466,42 @@ export const SYSTEM_CAPABILITIES: Record<AyanamsaSystem, SystemCapabilities> = {
     charts: ["progressed", "synastry", "composite"],
     features: ["progressed", "synastry", "composite"],
     specialCharts: [],
+    hasDivisional: false,
+    hasAshtakavarga: false,
+    hasNumerology: false,
+    hasHorary: false,
+  },
+  true_chitra: {
+    charts: [],
+    features: ["dasha"],
+    specialCharts: [
+      "prana",
+      "ashtottari",
+      "tribhagi",
+      "tribhagi-40",
+      "shodashottari",
+      "dwadashottari",
+      "dwisaptati",
+      "shastihayani",
+      "shattrimshatsama",
+      "panchottari",
+      "satabdika",
+      "chaturshitisama",
+    ],
+    dashas: [
+      "prana",
+      "ashtottari",
+      "tribhagi",
+      "tribhagi-40",
+      "shodashottari",
+      "dwadashottari",
+      "dwisaptati",
+      "shastihayani",
+      "shattrimshatsama",
+      "panchottari",
+      "satabdika",
+      "chaturshitisama",
+    ],
     hasDivisional: false,
     hasAshtakavarga: false,
     hasNumerology: false,

--- a/services/client-service/src/controllers/chart.controller.ts
+++ b/services/client-service/src/controllers/chart.controller.ts
@@ -123,17 +123,22 @@ export class ChartController {
         userAgent: req.get("user-agent"),
       };
 
+      // Normalize ayanamsa: frontend sends "truechitra" but backend uses "true_chitra"
+      const normalizedAyanamsa = (ayanamsa || "lahiri")
+        .toLowerCase()
+        .replace(/^truechitra$/, "true_chitra");
+
       const options = { mahaLord, antarLord, pratyantarLord, sookshmaLord };
 
       let dasha;
       if (level === "deep") {
-        dasha = await chartService.generateDeepDasha(tenantId, id, ayanamsa || "lahiri", metadata);
+        dasha = await chartService.generateDeepDasha(tenantId, id, normalizedAyanamsa, metadata);
       } else if (save) {
         dasha = await chartService.generateAndSaveDasha(
           tenantId,
           id,
           level || "mahadasha",
-          ayanamsa || "lahiri",
+          normalizedAyanamsa,
           options,
           metadata,
         );
@@ -142,7 +147,7 @@ export class ChartController {
           tenantId,
           id,
           level || "mahadasha",
-          ayanamsa || "lahiri",
+          normalizedAyanamsa,
           options,
         );
       }
@@ -201,11 +206,16 @@ export class ChartController {
 
       const options = { mahaLord, antarLord, pratyantarLord };
 
+      // Normalize ayanamsa: frontend sends "truechitra" but backend uses "true_chitra"
+      const normalizedAyanamsa = (ayanamsa || "lahiri")
+        .toLowerCase()
+        .replace(/^truechitra$/, "true_chitra");
+
       const dasha = await chartService.generateAlternativeDasha(
         tenantId,
         id,
         dashaType,
-        ayanamsa || "lahiri",
+        normalizedAyanamsa,
         level || "mahadasha",
         options,
         save || false,

--- a/services/client-service/src/services/chart.service.ts
+++ b/services/client-service/src/services/chart.service.ts
@@ -694,7 +694,7 @@ export class ChartService {
    * Bulk generate core charts (D1, D9) for all included systems
    */
   async generateCoreCharts(tenantId: string, clientId: string, metadata: RequestMetadata) {
-    const systems: AyanamsaSystem[] = ["lahiri", "raman", "kp", "bhasin"];
+    const systems: AyanamsaSystem[] = ["lahiri", "raman", "kp", "bhasin", "true_chitra"];
     const operations: (() => Promise<any>)[] = [];
 
     for (const sys of systems) {
@@ -766,7 +766,7 @@ export class ChartService {
       // 3. Define systems to check
       const systemsToCheck: AyanamsaSystem[] = targetSystem
         ? [targetSystem]
-        : ["lahiri", "kp", "raman", "yukteswar", "bhasin"];
+        : ["lahiri", "kp", "raman", "yukteswar", "bhasin", "true_chitra"];
 
       // Set lock to prevent overlapping audits
       generationLocks.add(clientId);
@@ -1036,7 +1036,7 @@ export class ChartService {
         }
       }
 
-      const ayanamsas: AyanamsaSystem[] = ["lahiri", "kp", "raman", "yukteswar", "bhasin"];
+      const ayanamsas: AyanamsaSystem[] = ["lahiri", "kp", "raman", "yukteswar", "bhasin", "true_chitra"];
 
       // 2. Sequential-Parallel Orchestration
       // To prevent connection pool exhaustion, we run 2 systems at a time
@@ -1191,7 +1191,11 @@ export class ChartService {
         );
       } else if (lowerType.startsWith("dasha_")) {
         // Correctly route dasha_tribhagi etc to generateAlternativeDasha
-        const dashaName = lowerType.replace("dasha_", "");
+        // For True Chitra, strip the _true_chitra suffix to get the dasha name
+        let dashaName = lowerType.replace("dasha_", "");
+        if (system === "true_chitra" && dashaName.endsWith("_true_chitra")) {
+          dashaName = dashaName.replace("_true_chitra", "");
+        }
         operations.push(() =>
           this.generateAlternativeDasha(
             tenantId,
@@ -2380,6 +2384,11 @@ export class ChartService {
           if (system === "lahiri" || system === "raman") {
             expected.push("dasha");
           }
+        } else if (system === "true_chitra") {
+          // True Chitra uses same dasha chart types as other systems
+          // The 'system' field distinguishes them in the DB
+          const type = d.toLowerCase().startsWith("dasha_") ? d : `dasha_${d}`;
+          expected.push(type);
         } else {
           // FIX: Avoid double prefixing dasha_dasha_
           const type = d.toLowerCase().startsWith("dasha_") ? d : `dasha_${d}`;


### PR DESCRIPTION
- Add true_chitra to Ayanamsa type and SYSTEM_CAPABILITIES
- Implement getTrueChitraDasha() with exact endpoint mapping for all 12 dasha types
- Route true_chitra ayanamsa requests to /true_chitra/* Python endpoints
- Add true_chitra normalization in chart controller (truechitra -> true_chitra)
- Include true_chitra in full vedic profile generation and chart completeness checks
- Store True Chitra dashas with system: true_chitra (reuses existing enum, no schema changes)